### PR TITLE
Update actions/checkout and actions/setup-node version on README.md and workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
   dirty:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-node@v2
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
       - run: npm ci
       - run: npm start
       - name: Compare the expected and actual dist/ directories
@@ -22,5 +22,5 @@ jobs:
     runs-on: ubuntu-20.04
     needs: [dirty]
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: ./

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ jobs:
   editorconfig:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - uses: editorconfig-checker/action-editorconfig-checker@main
       - run: editorconfig-checker
 ```


### PR DESCRIPTION
I just updated the README.md example and the .github/workflows/ci.yml to use `actions/checkout@v4` instead of `actions/checkout@v2` and `actions/setup-node@v4` instead of `actions/setup-node@v2` to resolve the following warning in the actions:

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

We have tested it on the bashunit actions, and [it works perfectly](https://github.com/TypedDevs/bashunit/actions/runs/8185116500) with the new version.