### PR TITLE
Make example workflow in README clearer

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,16 @@ on:
 
 jobs:
   editorconfig:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
-      - uses: actions/checkout@v4
-      - uses: editorconfig-checker/action-editorconfig-checker@main
-      - run: editorconfig-checker
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Set up editorconfig-checker
+        uses: editorconfig-checker/action-editorconfig-checker@main
+
+      - name: Run editorconfig-checker
+        run: editorconfig-checker
 ```
 
 ## License


### PR DESCRIPTION
At first, I thought the action also ran the command after setting up the environment. Later, I realized it only sets up the environment.

To avoid this confusion, it would be clearer to add names to the example workflow steps so it's obvious what each step does.