### PR TITLE
introduce a workflow to regenerate dist after dependabot updated

### DIFF
--- a/.github/workflows/regen-dist.yaml
+++ b/.github/workflows/regen-dist.yaml
@@ -1,0 +1,36 @@
+name: regenerate dist after dependabot updates
+on:
+  pull_request:
+    types: [opened, synchronize]
+    paths: &paths
+      - package*.json
+      - tsconfig.json
+      - src/**
+  push:
+    branches:
+      - main
+    paths: *paths
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build:
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: true
+          token: ${{ secrets.BOT_TOKEN }}
+      - uses: actions/setup-node@v6
+        with:
+          node-version-file: "package.json"
+      - run: npm ci
+      - run: npm start
+      - uses: stefanzweifel/git-auto-commit-action@v7
+        with:
+          commit_message: regenerate dist
+          
+              


### PR DESCRIPTION
This should solve #248. I'll be so frank and directly merge this, and try rebasing one of the existing dependabot PRs to test it out.