### PR TITLE
pin the default editorconfig-checker version instead of tracking latest

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,9 +16,15 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 ### Inputs
 
-| Field     | Description                 |
-| --------- | --------------------------- |
-| `version` | Version (default: `latest`) |
+| Field          | Description                                                                    |
+| -------------- | ------------------------------------------------------------------------------ |
+| `version`      | editorconfig-checker version to install (default: `v4.0.1`)                    |
+| `github-token` | Token used to look up the release to download (default: `${{ github.token }}`) |
+
+The `version` default is a pinned tag rather than `latest`, so that pinning this
+action to a commit SHA also pins the editorconfig-checker binary it installs.
+Set `version: latest` to opt back into always installing the newest release,
+at the cost of the installed binary no longer being determined by your pin.
 
 ### Example workflow
 

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: true
   version:
     description: EditorConfig Checker Version
-    default: latest
+    default: v4.0.1
     required: true
 
 runs:


### PR DESCRIPTION
Implements point 2 of #282.

`version` defaults to `latest`, which `findRelease()` resolves through the
releases API at run time. Pinning this action to a commit SHA therefore does
not pin the binary it installs: a consumer who pins everything correctly still
executes a moving artifact, and a new editorconfig-checker release can change
the behaviour of an unchanged workflow. That is the same root cause as #281,
where SHA-pinned v2.2.0 consumers broke when editorconfig-checker v4.0.0
renamed the binary.

This defaults `version` to `v4.0.1`, the current release, so the installed
binary is determined by the action pin alone. `latest` stays available as an
explicit opt-in for anyone who prefers it.

Also documents `github-token`, which was missing from the inputs table.

No `dist/` rebuild: the default is read from `action.yml` at run time.

### Keeping the pin fresh

You mentioned Renovate could automate the bump. I have not committed any config,
because Dependabot cannot track a version string inside `action.yml`, so this
needs the Renovate app enabled on the repo, and that is your call rather than
something a PR should decide. If you do want it:

```json
{
  "customManagers": [
    {
      "customType": "regex",
      "managerFilePatterns": ["/^action\\.yml$/"],
      "matchStrings": ["default: (?<currentValue>v\\S+)\\s+required: true"],
      "depNameTemplate": "editorconfig-checker/editorconfig-checker",
      "datasourceTemplate": "github-releases"
    }
  ]
}
```

Note that this PR only changes the default. Anyone who has explicitly set
`version: latest` keeps the old behaviour, so the bump cadence only matters for
consumers who take the default.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wmc3gzYRy4z1qXcVbTkruE
